### PR TITLE
Added Eclipse-specific files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Eclipse-specific files
+.classpath
+.project
+.settings/**/*
+bin/**/*
+
+
 # Compiled class file
 *.class
 
@@ -165,3 +172,4 @@ runner/
 courses_db
 
 #load_testing/
+


### PR DESCRIPTION
When working on Eclipse, several meta-data files will be created that are shown as "new" in the repository. These should be ignored so they do not get committed by accident.