### PR TITLE
Surpress hints for correct solutions

### DIFF
--- a/src/main/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluator.java
+++ b/src/main/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluator.java
@@ -47,14 +47,26 @@ public class CodeEvaluator implements StudentSubmissionEvaluator {
 		validate(submission, exercise);
 		CodeSubmission codeSub = (CodeSubmission) submission;
 
-		SubmissionEvaluation.Points scoredPoints = parseScoreFromLog(codeSub.getConsole().getEvalLog());
-		List<String> hints = parseHintsFromLog(codeSub.getConsole().getEvalLog());
+		String log = codeSub.getConsole().getEvalLog();
+
+		SubmissionEvaluation.Points scoredPoints = parseScoreFromLog(log);
+		List<String> hints = parseHintsFromLog(log);
+
+		if (exercise.getMaxScore() != scoredPoints.getMax()) {
+			logger.info(String.format("Weird inconsistency: exercise says maxSore=%d, log parsing says maxScore=%d",
+					exercise.getMaxScore(), scoredPoints.getMax()));
+		}
+
+		int maxScore = Math.max(exercise.getMaxScore(), scoredPoints.getMax());
+		if (scoredPoints.getCorrect() == maxScore) {
+			hints.clear();
+		}
 
 		return SubmissionEvaluation.builder().points(scoredPoints).maxScore(exercise.getMaxScore()).hints(hints)
 				.build();
 	}
 
-	List<String> parseHintsFromLog(String evalLog) {
+	public List<String> parseHintsFromLog(String evalLog) {
 		List<String> hints = new ArrayList<>();
 
 		Matcher matcher = hintPattern.matcher(evalLog);
@@ -98,10 +110,10 @@ public class CodeEvaluator implements StudentSubmissionEvaluator {
 			}
 		}
 
-		if(hints.isEmpty()) {
+		if (hints.isEmpty()) {
 			hints.add("No hint could be provided. This is likely caused by a crash during the execution.");
 		}
-		
+
 		return hints;
 	}
 
@@ -111,14 +123,20 @@ public class CodeEvaluator implements StudentSubmissionEvaluator {
 
 		if (log != null && !log.trim().isEmpty()) {
 			List<String> lines = Arrays.asList(log.split("\n"));
-			String resultLine = lines.get(lines.size() - 1);
+			if (lines.size() >= 3) {
+				String resultLine = lines.get(lines.size() - 1);
 
-			nrOfTest = extractNrOfTests(lines.get(lines.size() - 3));
+				nrOfTest = extractNrOfTests(lines.get(lines.size() - 3));
 
-			if (resultLine.startsWith("OK")) {
-				points = nrOfTest;
-			} else if (resultLine.startsWith("FAILED")) {
-				points = nrOfTest - extractNrOfNOKTests(resultLine);
+				if (resultLine.startsWith("OK")) {
+					points = nrOfTest;
+				} else if (resultLine.startsWith("FAILED")) {
+					points = nrOfTest - extractNrOfNOKTests(resultLine);
+				}
+			} else {
+				points = 0;
+				nrOfTest = 1;
+				logger.info("Log is too short, likely not a valid test output.");
 			}
 		} else {
 			logger.info("No console log to evaluate.");

--- a/src/main/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluator.java
+++ b/src/main/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluator.java
@@ -49,21 +49,10 @@ public class CodeEvaluator implements StudentSubmissionEvaluator {
 
 		String log = codeSub.getConsole().getEvalLog();
 
-		SubmissionEvaluation.Points scoredPoints = parseScoreFromLog(log);
-		List<String> hints = parseHintsFromLog(log);
+		SubmissionEvaluation.Points testResults = parseScoreFromLog(log);
+		List<String> hints = testResults.isEverythingCorrect() ? new ArrayList<String>() : parseHintsFromLog(log);
 
-		if (exercise.getMaxScore() != scoredPoints.getMax()) {
-			logger.info(String.format("Weird inconsistency: exercise says maxSore=%d, log parsing says maxScore=%d",
-					exercise.getMaxScore(), scoredPoints.getMax()));
-		}
-
-		int maxScore = Math.max(exercise.getMaxScore(), scoredPoints.getMax());
-		if (scoredPoints.getCorrect() == maxScore) {
-			hints.clear();
-		}
-
-		return SubmissionEvaluation.builder().points(scoredPoints).maxScore(exercise.getMaxScore()).hints(hints)
-				.build();
+		return SubmissionEvaluation.builder().points(testResults).maxScore(exercise.getMaxScore()).hints(hints).build();
 	}
 
 	public List<String> parseHintsFromLog(String evalLog) {

--- a/src/main/java/ch/uzh/ifi/access/student/model/SubmissionEvaluation.java
+++ b/src/main/java/ch/uzh/ifi/access/student/model/SubmissionEvaluation.java
@@ -1,12 +1,17 @@
 package ch.uzh.ifi.access.student.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
-
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Value;
 
 @SuppressWarnings("unused")
 @Value
@@ -14,38 +19,42 @@ import java.util.List;
 @Builder
 public class SubmissionEvaluation {
 
-    public static SubmissionEvaluation NO_SUBMISSION = new SubmissionEvaluation(new Points(0, 0), 0, Instant.MIN, Collections.emptyList());
+	public static SubmissionEvaluation NO_SUBMISSION = new SubmissionEvaluation(new Points(0, 0), 0, Instant.MIN,
+			Collections.emptyList());
 
-    private Points points;
+	private Points points;
 
-    private int maxScore;
+	private int maxScore;
 
-    private Instant timestamp;
+	private Instant timestamp;
 
-    private List<String> hints;
+	private List<String> hints;
 
-    @JsonProperty
-    public boolean hasSubmitted() {
-        return !NO_SUBMISSION.equals(this);
-    }
+	@JsonProperty
+	public boolean hasSubmitted() {
+		return !NO_SUBMISSION.equals(this);
+	}
 
-    public double getScore() {
-        if(points.getMax() == 0){
-            return 0.0;
-        }
-        return Math.round((points.getCorrect() / (double) points.getMax() * maxScore) * 4) / 4d;
-    }
+	public double getScore() {
+		if (points.getMax() == 0) {
+			return 0.0;
+		}
+		return Math.round((points.getCorrect() / (double) points.getMax() * maxScore) * 4) / 4d;
+	}
 
-    public List<String> getHints() {
-        return hints != null && hints.size() > 1 ? Arrays.asList(hints.get(0)) : hints;
-    }
+	public List<String> getHints() {
+		return hints != null && hints.size() > 1 ? Arrays.asList(hints.get(0)) : hints;
+	}
 
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class Points {
-        private int correct;
-        private int max;
-    }
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Points {
+		private int correct;
+		private int max;
 
+		public boolean isEverythingCorrect() {
+			return correct == max;
+		}
+	}
 }

--- a/src/test/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluatorTest.java
+++ b/src/test/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluatorTest.java
@@ -164,7 +164,7 @@ public class CodeEvaluatorTest {
 				+ "- zayZY!\n" + "+ abzAZ!\n" + " : @@ROT-27 of 'abzAZ!' should be 'zayZY!'\n"
 				+ ", but was 'abzAZ!'.@@\n" + "\n"
 				+ "----------------------------------------------------------------------\n"
-				+ "Ran 12 tests in 0.016s\n" + "\n" + "FAILED (failures=2)\n";
+				+ "Ran 10 tests in 0.016s\n" + "\n" + "FAILED (failures=2)\n";
 
 		List<String> actuals = extractAllHints(output);
 		List<String> expecteds = hints("ROT27 of 'abzAZ!' should be 'bcaBA!'\n, but was 'abzAZ!'.",
@@ -419,10 +419,24 @@ public class CodeEvaluatorTest {
 	}
 
 	@Test
-	public void errorUnspecified() {
+	public void noPointsErrorUnspecified() {
 		List<String> actuals = extractAllHints("Some output, no ok, no testing...");
 		List<String> expecteds = hints(
 				"No hint could be provided. This is likely caused by a crash during the execution.");
 		assertEquals(expecteds, actuals);
+	}
+
+	@Test
+	public void maxPointsNoError() {
+		exercise.setMaxScore(0);
+		String in = "Some output, no ok, no testing...";
+		List<String> actuals = extractAllHints(in);
+		List<String> expecteds = hints(
+				"No hint could be provided. This is likely caused by a crash during the execution.");
+		assertEquals(expecteds, actuals);
+
+		// evaluate gets rid of hints, in case of a correct implementation (score == maxScore)
+		actuals = evaluate(in).getHints();
+		assertEquals(hints(), actuals);
 	}
 }

--- a/src/test/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluatorTest.java
+++ b/src/test/java/ch/uzh/ifi/access/student/evaluation/evaluator/CodeEvaluatorTest.java
@@ -428,15 +428,23 @@ public class CodeEvaluatorTest {
 
 	@Test
 	public void maxPointsNoError() {
-		exercise.setMaxScore(0);
-		String in = "Some output, no ok, no testing...";
+
+		String in = "test_isupper (test.TestStringMethods1.TestStringMethods1) ... ok\n"
+				+ "test_split (test.TestStringMethods1.TestStringMethods1) ... ok\n"
+				+ "test_upper (test.TestStringMethods1.TestStringMethods1) ... ok\n"
+				+ "test_isupper (test.TestStringMethods2.TestStringMethods2) ... ok\n"
+				+ "test_split (test.TestStringMethods2.TestStringMethods2) ... ok\n"
+				+ "test_upper (test.TestStringMethods2.TestStringMethods2) ... ok\n" + "\n"
+				+ "----------------------------------------------------------------------\n" + "Ran 6 tests in 0.001s\n"
+				+ "\n" + "OK\n";
+
 		List<String> actuals = extractAllHints(in);
 		List<String> expecteds = hints(
 				"No hint could be provided. This is likely caused by a crash during the execution.");
 		assertEquals(expecteds, actuals);
 
-		// evaluate gets rid of hints, in case of a correct implementation (score == maxScore)
 		actuals = evaluate(in).getHints();
-		assertEquals(hints(), actuals);
+		expecteds = hints();
+		assertEquals(expecteds, actuals);
 	}
 }


### PR DESCRIPTION
Correct cases have included the fallback solution hint, because the list of hints was empty. I added a check and the CodeEvaluator clears any hint now, when the maximum score has been reached.